### PR TITLE
Fix getopt MacOS path

### DIFF
--- a/bin/git-signatures
+++ b/bin/git-signatures
@@ -35,6 +35,7 @@ getopt_path() {
         echo "Error: Found getopt is not GNU getopt." >&2
         [[ "$os_name" == "Darwin" ]] && echo "$hint_macos" >&2 || echo "$hint_linux" >&2
         exit 1
+	fi
 }
 
 

--- a/bin/git-signatures
+++ b/bin/git-signatures
@@ -35,7 +35,7 @@ getopt_path() {
         echo "Error: Found getopt is not GNU getopt." >&2
         [[ "$os_name" == "Darwin" ]] && echo "$hint_macos" >&2 || echo "$hint_linux" >&2
         exit 1
-	fi
+    fi
 }
 
 

--- a/bin/git-signatures
+++ b/bin/git-signatures
@@ -6,7 +6,27 @@ VERSION="v0.1.0"
 PROGRAM="${0##*/}"
 COMMAND="$1"
 
-GETOPT=$(command -v gnu-getopt || command -v getopt)
+getopt_path() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        local mac_getopt='/opt/homebrew/opt/gnu-getopt/bin/getopt'
+        if [[ -x "$mac_getopt" ]]; then
+            echo "$mac_getopt"
+            return 0
+        fi
+    fi
+
+    local found_getopt=$(command -v gnu-getopt || command -v getopt)
+
+    if [[ -z "$found_getopt" ]]; then
+        echo "Error: getopt is not installed." >&2
+        exit 1
+    fi
+
+    echo "$found_getopt"
+}
+
+
+GETOPT=$(getopt_path)
 DATE=$(command -v gdate || command -v date)
 SHUF=$(command -v gshuf || command -v shuf)
 

--- a/bin/git-signatures
+++ b/bin/git-signatures
@@ -8,15 +8,15 @@ COMMAND="$1"
 
 getopt_path() {
     if [[ "$(uname)" == "Darwin" ]]; then
-        local mac_getopt='/opt/homebrew/opt/gnu-getopt/bin/getopt'
-        if [[ -x "$mac_getopt" ]]; then
-            echo "$mac_getopt"
+        local brew_prefix
+        brew_prefix=$(brew --prefix gnu-getopt 2>/dev/null)
+        if [[ -n "$brew_prefix" ]]; then
+            echo "$brew_prefix/bin/getopt"
             return 0
         fi
     fi
 
     local found_getopt=$(command -v gnu-getopt || command -v getopt)
-
     if [[ -z "$found_getopt" ]]; then
         echo "Error: getopt is not installed." >&2
         exit 1

--- a/bin/git-signatures
+++ b/bin/git-signatures
@@ -7,22 +7,34 @@ PROGRAM="${0##*/}"
 COMMAND="$1"
 
 getopt_path() {
-    if [[ "$(uname)" == "Darwin" ]]; then
-        local brew_prefix
-        brew_prefix=$(brew --prefix gnu-getopt 2>/dev/null)
-        if [[ -n "$brew_prefix" ]]; then
-            echo "$brew_prefix/bin/getopt"
-            return 0
+    local os_name=$(uname)
+    local hint_macos="Hint: Install GNU getopt using 'brew install gnu-getopt'"
+    local hint_linux="Hint: Install GNU getopt using your package manager (e.g., 'sudo apt install getopt')"
+
+    if [[ "$os_name" == "Darwin" ]]; then
+        if brew list gnu-getopt &>/dev/null; then
+            local brew_prefix=$(brew --prefix gnu-getopt 2>/dev/null)
+            if [[ -n "$brew_prefix" ]]; then
+                echo "$brew_prefix/bin/getopt"
+                return 0
+            fi 
         fi
-    fi
+    fi    
 
     local found_getopt=$(command -v gnu-getopt || command -v getopt)
+
     if [[ -z "$found_getopt" ]]; then
         echo "Error: getopt is not installed." >&2
+        [[ "$os_name" == "Darwin" ]] && echo "$hint_macos" >&2 || echo "$hint_linux" >&2
         exit 1
     fi
 
-    echo "$found_getopt"
+    if "$found_getopt" -V 2>&1 | grep -q "getopt"; then
+        echo "$found_getopt"
+    else
+        echo "Error: Found getopt is not GNU getopt." >&2
+        [[ "$os_name" == "Darwin" ]] && echo "$hint_macos" >&2 || echo "$hint_linux" >&2
+        exit 1
 }
 
 


### PR DESCRIPTION
There is a problem with get-opt path in MacOS. This should fix it and use gnu-get-opt installed from brew. Fallback is also added